### PR TITLE
fix: mock ExtensionRuntime crashes researcher sessions on pi 0.81

### DIFF
--- a/src/utils/make-resource-loader.ts
+++ b/src/utils/make-resource-loader.ts
@@ -8,9 +8,14 @@
 import type { ResourceLoader, ExtensionRuntime } from '@earendil-works/pi-coding-agent';
 
 export function makeResourceLoader(systemPromptText: string): ResourceLoader {
-  const mockRuntime: ExtensionRuntime = {
+  // Cast (not annotation) so this compiles against both pi 0.80 (no
+  // pendingNativeProviderRegistrations/registerNativeProvider on ExtensionRuntime)
+  // and 0.81 (where createAgentSessionServices iterates that array unconditionally).
+  const mockRuntime = {
     flagValues: new Map(),
     pendingProviderRegistrations: [],
+    pendingNativeProviderRegistrations: [],
+    registerNativeProvider: () => {},
     registerProvider: () => {},
     unregisterProvider: () => {},
     sendMessage: async () => {},
@@ -29,7 +34,7 @@ export function makeResourceLoader(systemPromptText: string): ResourceLoader {
     setThinkingLevel: () => {},
     assertActive: () => {},
     invalidate: () => {},
-  };
+  } as ExtensionRuntime;
 
   return {
     getExtensions: () => ({ extensions: [], errors: [], runtime: mockRuntime }),


### PR DESCRIPTION
## Problem

On pi-coding-agent 0.81.x, every research run fails immediately:

```
Research failed: Research produced no report — no source material was collected.
Causes: researcher 1.1: Failed to create researcher session:
this.runtime.pendingNativeProviderRegistrations is not iterable
```

`createAgentSessionServices` in pi 0.81 gained a second registration drain loop that iterates `extensionsResult.runtime.pendingNativeProviderRegistrations` unconditionally (dist/core/agent-session-services.js). The mock `ExtensionRuntime` in `src/utils/make-resource-loader.ts` (used for researcher and coordinator sessions) predates that field, so session creation throws before any researcher starts.

pi-research declares `>=0.80.7 <1`, so 0.81 installs are entirely within the supported range.

## Fix

Add `pendingNativeProviderRegistrations: []` and `registerNativeProvider: () => {}` to the mock, and switch the object literal from a type annotation to an `as ExtensionRuntime` cast. A plain annotation breaks typecheck on the 0.80 types (excess-property check on the two new fields); the cast compiles cleanly against both 0.80 and 0.81, and the extra fields are ignored by 0.81's predecessors at runtime.

## Verification

- `npx tsc --noEmit` clean against the repo lockfile (pi 0.80.10)
- `npm run test:unit`: 1935/1938 pass. The single failure (`skill-installer.test.ts > creates an owned symlink`) reproduces on unmodified `main` on macOS and is unrelated to this change.
- Live-tested on pi 0.81.1: researcher sessions create successfully and runs complete again.

Repro: install pi-research 1.0.8 on pi 0.81.1, run any `research` tool call with depth 1.