### PR TITLE
fix: normalize 'off' reasoning to undefined at the compat boundary

### DIFF
--- a/src/core/llm/llm-utils.ts
+++ b/src/core/llm/llm-utils.ts
@@ -14,10 +14,8 @@ import { completeSimple } from './pi-ai-completion.ts';
  *
  * - Ensures maxTokens is always set (satisfies providers that reject a null cap),
  *   clamped to the model's own ceiling so a large requested cap is never invalid.
- * - Sets the chain-of-thought "thinking" level, defaulting to 'off'. This is passed
- *   straight to pi-ai, which clamps it to whatever the specific model/provider
- *   supports (disabling thinking where an off state exists, omitting the parameter
- *   where it does not). The fix is therefore model-agnostic — pi-ai owns the
+ * - Sets the chain-of-thought "thinking" level, defaulting to 'off' (normalized to
+ *   undefined at the compat boundary, see the reasoning line below). pi-ai owns the
  *   per-provider translation; this code never hardcodes a provider-specific payload.
  *   'off' is deliberate: these engine calls emit structured JSON / cited reports, so a
  *   thinking block only consumes the output-token budget (often truncating before the
@@ -47,9 +45,9 @@ export function buildSafeOptions(
     ...options,
     // Ensure maxTokens is never null/None to avoid provider-side crashes
     maxTokens: options.maxTokens ?? Math.min(defaultCap, model.maxTokens || defaultCap),
-    // 'off' is a valid ModelThinkingLevel that pi-ai accepts at runtime even though the
-    // public SimpleStreamOptions.reasoning type narrows to the non-off ThinkingLevel.
-    reasoning: effective as unknown as SimpleStreamOptions['reasoning'],
+    // compat API treats any truthy reasoning as thinking-enabled; 'off' has no budget
+    // entry, so it would send maxTokens as NaN. undefined is its no-reasoning value.
+    reasoning: effective === 'off' ? undefined : (effective as SimpleStreamOptions['reasoning']),
   };
 }
 

--- a/test/unit/core/llm/build-safe-options.test.ts
+++ b/test/unit/core/llm/build-safe-options.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../../src/logger.ts', () => ({
+  logger: { log: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { buildSafeOptions } from '../../../../src/core/llm/llm-utils.ts';
+import { completeSimple } from '@earendil-works/pi-ai/compat';
+
+const STUB_MODEL = {
+  id: 'qwen3p8-max',
+  provider: 'fireworks',
+  api: 'anthropic-messages',
+  baseUrl: 'https://api.fireworks.ai/inference',
+  maxTokens: 32768,
+  reasoning: false,
+} as any;
+
+describe('buildSafeOptions', () => {
+  it('normalizes the default off level to undefined for the compat API', () => {
+    expect(buildSafeOptions(STUB_MODEL, {}).reasoning).toBeUndefined();
+  });
+
+  it('normalizes an explicit caller-provided off', () => {
+    expect(buildSafeOptions(STUB_MODEL, { reasoning: 'off' as any }).reasoning).toBeUndefined();
+  });
+
+  it('preserves valid non-off reasoning levels', () => {
+    expect(buildSafeOptions(STUB_MODEL, { reasoning: 'low' }).reasoning).toBe('low');
+    expect(buildSafeOptions(STUB_MODEL, {}, 4096, 'medium').reasoning).toBe('medium');
+  });
+
+  it('caller reasoning wins over the thinkingLevel argument', () => {
+    expect(buildSafeOptions(STUB_MODEL, { reasoning: 'high' }, 4096, 'low').reasoning).toBe('high');
+  });
+
+  it('fills maxTokens from the default cap, clamped to the model ceiling', () => {
+    expect(buildSafeOptions(STUB_MODEL, {}).maxTokens).toBe(4096);
+    expect(buildSafeOptions({ ...STUB_MODEL, maxTokens: 1000 }, {}).maxTokens).toBe(1000);
+    expect(buildSafeOptions(STUB_MODEL, { maxTokens: 8192 }).maxTokens).toBe(8192);
+  });
+
+  it('preserves unrelated options', () => {
+    const opts = buildSafeOptions(STUB_MODEL, { sessionId: 's1', apiKey: 'k' } as any);
+    expect((opts as any).sessionId).toBe('s1');
+    expect(opts.apiKey).toBe('k');
+  });
+});
+
+// End-to-end through the real compat API with a stubbed transport: a truthy
+// 'off' takes pi-ai's thinking path, where the unknown level yields an undefined
+// budget and maxTokens goes out as null (Fireworks 400s on it). Regression for
+// that serialization, not just the helper's return value.
+describe('compat serialization (real pi-ai, stubbed transport)', () => {
+  const FIREWORKS_MODEL = {
+    ...STUB_MODEL,
+    contextWindow: 131072,
+    input: ['text'],
+    output: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  } as any;
+
+  const SSE_OK = [
+    'event: message_start',
+    'data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"stub","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}}',
+    '',
+    'event: content_block_start',
+    'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+    '',
+    'event: content_block_delta',
+    'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}',
+    '',
+    'event: content_block_stop',
+    'data: {"type":"content_block_stop","index":0}',
+    '',
+    'event: message_delta',
+    'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}',
+    '',
+    'event: message_stop',
+    'data: {"type":"message_stop"}',
+    '',
+    '',
+  ].join('\n');
+
+  async function captureRequestBody(options: any): Promise<any> {
+    let body: any;
+    const fetchStub = vi.fn(async (_url: any, init: any) => {
+      body = JSON.parse(init.body);
+      return new Response(SSE_OK, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+    });
+    await completeSimple(
+      FIREWORKS_MODEL,
+      { messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }], timestamp: 0 }] } as any,
+      { apiKey: 'test-key', fetch: fetchStub, ...options } as any,
+    );
+    return body;
+  }
+
+  it('off (the default) sends a finite positive max_tokens, never null', async () => {
+    const body = await captureRequestBody(buildSafeOptions(FIREWORKS_MODEL, {}));
+    expect(Number.isInteger(body.max_tokens)).toBe(true);
+    expect(body.max_tokens).toBeGreaterThan(0);
+  });
+
+  it('an explicit off is equally safe', async () => {
+    const body = await captureRequestBody(buildSafeOptions(FIREWORKS_MODEL, { reasoning: 'off' as any }));
+    expect(Number.isInteger(body.max_tokens)).toBe(true);
+    expect(body.max_tokens).toBeGreaterThan(0);
+  });
+
+  it('off does not take the thinking path (no budget inflates max_tokens)', async () => {
+    const off = await captureRequestBody(buildSafeOptions(FIREWORKS_MODEL, {}));
+    const low = await captureRequestBody(buildSafeOptions(FIREWORKS_MODEL, { reasoning: 'low' }));
+    expect(low.max_tokens).toBe(4096 + 2048); // 'low' budget is 2048 in pi-ai
+    expect(off.max_tokens).toBe(4096);
+  });
+});

--- a/test/unit/core/planning-service.test.ts
+++ b/test/unit/core/planning-service.test.ts
@@ -500,8 +500,9 @@ describe('PlanningService', () => {
       // Coordinator uses PLANNING_MAX_TOKENS (default 16384), clamped to the model ceiling
       // (STUB_MODEL has no maxTokens so the default is the binding cap) — no longer the old 4096.
       expect(callOptions.maxTokens).toBe(16384);
-      // Thinking is off by default for the engine's structured-JSON calls.
-      expect(callOptions.reasoning).toBe('off');
+      // Thinking is off by default for the engine's structured-JSON calls;
+      // off crosses into the compat API as undefined, not a literal string.
+      expect(callOptions.reasoning).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Problem

`buildSafeOptions` defaults the thinking level to `'off'` and passed it straight into pi-ai's compat API (`completeSimple` from `@earendil-works/pi-ai/compat`), through an `as unknown as` cast that bypasses the type narrowing `reasoning` to non-off levels.

The compat API does not accept `'off'` at runtime. In the anthropic-messages adapter (`dist/api/anthropic-messages.js`, pi-ai 0.85.1), any truthy `options.reasoning` takes the thinking path:

- `thinkingBudgetForLevel('off')` returns `undefined` (`DEFAULT_THINKING_BUDGETS` has no `off` key)
- `Math.min(baseMaxTokens + undefined, modelMaxTokens)` is `NaN`
- JSON serialization turns `NaN` into `null`, so the request goes out with `max_tokens: null`

Providers that validate the cap reject the call. Observed on Fireworks (anthropic-messages endpoint, model `accounts/fireworks/models/qwen3p8-max`), where every coordinator call failed before any research happened:

```
Coordinator failed: 400 {"error":{"type":"invalid_request_error","message":"max_tokens is required and must be > 0"}}
```

Pure-dependency reproduction against pi-ai 0.85.1, no model call needed:

```js
adjustMaxTokensForThinking(4096, 32768, 'off')
// { maxTokens: NaN, thinkingBudget: undefined }  -> serialized as null
adjustMaxTokensForThinking(4096, 32768, 'low')
// { maxTokens: 6144, thinkingBudget: 2048 }
```

## Fix

One line in `buildSafeOptions`: `'off'` is normalized to `undefined`, the compat API's no-reasoning representation, before the options cross into pi-ai. Valid non-off levels, caller precedence (explicit `options.reasoning` still wins), the maxTokens cap, and all other options are unchanged. The stale comment claiming pi-ai accepts `'off'` at runtime is corrected.

This is model-agnostic: it fixes the request normalization at the shared boundary rather than special-casing any provider.

## Tests

New `test/unit/core/llm/build-safe-options.test.ts` (9 tests):

- helper level: default off and explicit off normalize to undefined; non-off levels preserved; caller precedence; maxTokens defaulting/clamping; unrelated options untouched
- serialization level: drives the **real** compat `completeSimple` (pi-ai 0.85.1) with a stubbed `fetch` and asserts on the actual request body. Off sends a finite positive `max_tokens` (4096) and never takes the thinking path; `low` still sends 4096 + 2048 budget. 5 of the 9 fail pre-patch, all pass post-patch.

Also updates the one existing assertion that expected the literal `reasoning: 'off'` at the coordinator boundary (`planning-service.test.ts`) to expect `undefined`, per the compat contract.

Verified end-to-end with the patched build installed over 1.6.17: a depth-1 research run against the same Fireworks model that produced the 400 now completes with planned=launched=succeeded=1.

`tsc --noEmit` (src + tests), eslint, and the unit suite pass (3072/3073; the single failure is a pre-existing skill-installer symlink test that fails identically on unmodified main).